### PR TITLE
Remove `init()` warning.

### DIFF
--- a/src/ip3country.js
+++ b/src/ip3country.js
@@ -5,7 +5,6 @@ const ip3country = {
 
   init: function () {
     if (this._initCalled) {
-      console.warn("ip3country::init> You can call init just once");
       return;
     }
 


### PR DESCRIPTION
It doesn't help much, and it's hard to avoid calling `init` multiple times when you have multiple libraries where each uses ip3country.